### PR TITLE
Update PyProject Toml - License

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "comfyui_mooer"
 description = "MooER is an LLM-based Speech Recognition and Translation Model from Moore Threads.You can use MooER when install ComfyUI_MooER node"
 version = "1.0.0"
-license = "LICENSE"
+license = { file = "LICENSE.md" }
 dependencies = ["#black", "modelscope", "fire", "#torch>=2.0.0", "#accelerate==0.33.0", "#appdirs", "#loralib", "#bitsandbytes", "#peft", "#transformers==4.40.2", "#sentencepiece", "#py7zr", "#scipy", "#optimum", "#wandb", "#sox", "#hydra-core>=1.3.2", "#deepspeed==0.14.4", "#whisper", "#soundfile", "#datasets"]
 
 [project.urls]


### PR DESCRIPTION
Hey! Robin from [comfy.org](https://comfy.org/) again 😊.

As a heads up, the `license` field is **optional** but in the case that it is filled out, the license file should be referenced either by the file path or by the name of the license.
- `license = { file = "LICENSE" }` ✅
- `license = {text = "MIT License"}` ✅
- `license = "LICENSE"` ❌
- `license = "MIT LICENSE"` ❌

This was brought up in our discord and so we're creating a small PR to update that optional field. For more info check out toml file [standards](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license) or our [docs](https://docs.comfy.org/registry/specifications#license) page!